### PR TITLE
[TR#15] Fix inaccurate and jumpy compass

### DIFF
--- a/utils/Navigator.js
+++ b/utils/Navigator.js
@@ -36,26 +36,6 @@ export default class Navigator {
     })
   }
 
-  _degree(angle) {
-    return angle - 90 >= 0 ? angle - 90 : angle + 271;
-  }
-
-  _angle(magnetometer) {
-
-    if (magnetometer) {
-      let {x, y} = magnetometer;
-
-      if (Math.atan2(y, x) >= 0) {
-        angle = Math.atan2(y, x) * (180 / Math.PI);
-      }
-      else {
-        angle = (Math.atan2(y, x) + 2 * Math.PI) * (180 / Math.PI);
-      }
-    }
-
-    return Math.round(angle);
-  }
-
   watchHeading(options, headingCallback) {
     let lastAccuracy = 0
     return Location.watchHeadingAsync(({magHeading, trueHeading, accuracy}) => {

--- a/utils/Navigator.js
+++ b/utils/Navigator.js
@@ -57,9 +57,22 @@ export default class Navigator {
   }
 
   watchHeading(options, headingCallback) {
-    return Magnetometer.addListener(magData => {
-      const heading = this._degree(this._angle(magData))
-      headingCallback(heading)
+    let lastAccuracy = 0
+    return Location.watchHeadingAsync(({magHeading, trueHeading, accuracy}) => {
+      if (accuracy !== lastAccuracy) {
+        let uncertainty = "<20"
+        if (accuracy === 2) {
+          uncertainty = "<35"
+        } else if (accuracy === 1) {
+          uncertainty = "<50"
+        } else if (accuracy === 0) {
+          uncertainty = ">50"
+        }
+        console.log(`Heading ${trueHeading} +/- ${uncertainty}`)
+        lastAccuracy = accuracy
+      }
+
+      headingCallback(Math.round(trueHeading))
     })
   }
 

--- a/views/CompassView.js
+++ b/views/CompassView.js
@@ -30,10 +30,8 @@ export default class CompassView extends React.Component {
   }
 
   componentDidMount() {
-    this._subscription = this._navigator.watchHeading(
-      {},
-      this.updateHeading.bind(this)
-    );
+    this._navigator.watchHeading({}, this.updateHeading.bind(this))
+        .then(subscription => this._subscription = subscription);
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
Coming out of hack upstate, the compass was unreliable:
- If you tilted your phone, the compass would completely change direction
- Even if you turned, occasionally the compass wouldn't turn as much as you did
- Occasionally, the compass would have the wrong heading

This PR changes the source of heading from react-native Magnetometer to Expo Location. This fixes the first two and highly improves the third (along with minor calibration motions)